### PR TITLE
PCQ_685 - Moved TestUtils to src/main

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcq/commons/tests/utils/TestUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcq/commons/tests/utils/TestUtils.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.pcq.commons.utils;
+package uk.gov.hmcts.reform.pcq.commons.tests.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.core.io.ClassPathResource;

--- a/src/main/java/uk/gov/hmcts/reform/pcq/commons/utils/TestUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcq/commons/utils/TestUtils.java
@@ -13,6 +13,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * This class is used by the components in their test framework.
+ */
 public class TestUtils {
 
     private static final String CO_RELATION_ID_FOR_TEST = "Test-Id";


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ-685


### Change description ###
Moved the TestUtils class to src/main as it is needed by the components to be used in their test classes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
