### PR TITLE
Pcq-984 OptOut flag addition

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswers.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswers.java
@@ -111,7 +111,7 @@ public class PcqAnswers implements Serializable {
     @JsonProperty("pregnancy")
     private Integer pregnancy;
 
-    @JsonProperty("OPT_OUT")
+    @JsonProperty("opt_out")
     private Boolean optOut;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswers.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswers.java
@@ -110,4 +110,8 @@ public class PcqAnswers implements Serializable {
 
     @JsonProperty("pregnancy")
     private Integer pregnancy;
+
+    @JsonProperty("OPT_OUT")
+    private Boolean optOut;
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswerRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswerRequestTest.java
@@ -22,6 +22,7 @@ public class PcqAnswerRequestTest {
     private static final String DOB = "01-01-1999T00:00:00.000Z";
     private static final Integer ANSWER_RESPONSE_INT = 1;
     private static final String ANSWER_RESPONSE_TEXT = "Other Test";
+    private static final Boolean ANSWER_OPT_OUT = true;
 
     @Test
     void testPcqAnswerRequest() {
@@ -60,6 +61,7 @@ public class PcqAnswerRequestTest {
         pcqAnswers.setSexualityOther(ANSWER_RESPONSE_TEXT);
         pcqAnswers.setPregnancy(ANSWER_RESPONSE_INT);
         pcqAnswers.setMarriage(ANSWER_RESPONSE_INT);
+        pcqAnswers.setOptOut(ANSWER_OPT_OUT);
 
         pcqAnswerRequest.setPcqAnswers(pcqAnswers);
 
@@ -100,7 +102,7 @@ public class PcqAnswerRequestTest {
         assertEquals(ANSWER_RESPONSE_TEXT, answers.getSexualityOther(), "Sexuality Other is invalid");
         assertEquals(ANSWER_RESPONSE_INT, answers.getPregnancy(), "Pregnancy is invalid");
         assertEquals(ANSWER_RESPONSE_INT, answers.getMarriage(), "Marriage is invalid");
-
+        assertEquals(ANSWER_OPT_OUT, answers.getOptOut(), "OptOut is invalid");
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcq/commons/model/PcqAnswersTest.java
@@ -44,6 +44,7 @@ class PcqAnswersTest {
         answers.setSex(2);
         answers.setSexuality(4);
         answers.setSexualityOther("Other");
+        answers.setOptOut(false);
     }
 
     private void assertAnswers(PcqAnswers answers) {
@@ -107,5 +108,7 @@ class PcqAnswersTest {
                 answers.getSexuality().intValue());
         assertEquals("Sexuality Other is not matching", "Other",
                 answers.getSexualityOther());
+        assertEquals("OptOut is not matching", false,
+                answers.getOptOut());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-984


### Change description ###
This change is to add new optOut column in PcqAnswers so that when calling get the record , it will return this column as well.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
